### PR TITLE
feat: Drop zone for save files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@etothepii/satisfactory-file-parser": "^2.0.1",
         "@mantine/colors-generator": "^7.13.4",
         "@mantine/core": "7.13.4",
+        "@mantine/dropzone": "^7.13.4",
         "@mantine/hooks": "7.13.4",
         "@mantine/modals": "^7.13.4",
         "@mantine/notifications": "^7.13.4",
@@ -1508,6 +1509,21 @@
         "type-fest": "^4.12.0"
       },
       "peerDependencies": {
+        "@mantine/hooks": "7.13.4",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@mantine/dropzone": {
+      "version": "7.13.4",
+      "resolved": "https://registry.npmjs.org/@mantine/dropzone/-/dropzone-7.13.4.tgz",
+      "integrity": "sha512-RmiBfi+u16vh0ZUjJvn8cUfsgScN0o/F/P4mZUFm7AE4ap7jUdIyBWr4aBiHu0v5DXKywNO6ZrsSaoZnpbiUgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-dropzone-esm": "15.0.1"
+      },
+      "peerDependencies": {
+        "@mantine/core": "7.13.4",
         "@mantine/hooks": "7.13.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -6920,6 +6936,21 @@
       },
       "peerDependencies": {
         "react": ">= 16.8"
+      }
+    },
+    "node_modules/react-dropzone-esm": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone-esm/-/react-dropzone-esm-15.0.1.tgz",
+      "integrity": "sha512-RdeGpqwHnoV/IlDFpQji7t7pTtlC2O1i/Br0LWkRZ9hYtLyce814S71h5NolnCZXsIN5wrZId6+8eQj2EBnEzg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@etothepii/satisfactory-file-parser": "^2.0.1",
     "@mantine/colors-generator": "^7.13.4",
     "@mantine/core": "7.13.4",
+    "@mantine/dropzone": "^7.13.4",
     "@mantine/hooks": "7.13.4",
     "@mantine/modals": "^7.13.4",
     "@mantine/notifications": "^7.13.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Center, Loader, MantineProvider, Modal } from '@mantine/core';
 import '@mantine/core/styles.css';
+import '@mantine/dropzone/styles.css';
 import { Notifications } from '@mantine/notifications';
 import '@mantine/notifications/styles.css';
 

--- a/src/recipes/savegame/ImportSavegameRecipesModal.tsx
+++ b/src/recipes/savegame/ImportSavegameRecipesModal.tsx
@@ -2,13 +2,15 @@ import {
   Button,
   Checkbox,
   Divider,
-  FileButton,
+  Group,
   Modal,
   Progress,
   Stack,
   Text,
+  ThemeIcon,
   Tooltip,
 } from '@mantine/core';
+import { Dropzone } from '@mantine/dropzone';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { IconCloudUpload } from '@tabler/icons-react';
@@ -83,7 +85,7 @@ export function ImportSavegameRecipesModal(props: IImportSavegameModalProps) {
             description="If checked, imported recipes will be set as default for this game: new factories will have these recipes selected by default"
           />
 
-          <FileButton
+          {/* <FileButton
             onChange={file => {
               if (!file) {
                 return;
@@ -102,7 +104,33 @@ export function ImportSavegameRecipesModal(props: IImportSavegameModalProps) {
                 Select Savegame
               </Button>
             )}
-          </FileButton>
+          </FileButton> */}
+
+          <Dropzone
+            onDrop={files => {
+              if (!files[0]) return;
+
+              handleImport(files[0]);
+            }}
+            accept={['.sav']}
+            multiple={false}
+            loading={importing}
+            style={{
+              borderColor: 'var(--mantine-color-satisfactory-orange-5)',
+            }}
+            bd="satisfactory-orange"
+          >
+            <Group justify="center" gap="md">
+              <Dropzone.Idle>
+                <ThemeIcon variant="transparent" c="satisfactory-orange">
+                  <IconCloudUpload size={20} />
+                </ThemeIcon>
+              </Dropzone.Idle>
+              <Text size="md" c="satisfactory-orange">
+                Click to upload or drag a save file here
+              </Text>
+            </Group>
+          </Dropzone>
 
           {importing && (
             <>


### PR DESCRIPTION
Found it cumbersome to continually navigate to my save file location and instead made a drop zone so I can keep the folder open and just drop the save file rather than deal with the navigator.

![image](https://github.com/user-attachments/assets/760ee38b-dc90-4138-9431-d68ed350b93e)
