### PR TITLE
feat: Link to input factory from consuming factory

### DIFF
--- a/src/solver/layout/nodes/resource-node/ResourceNode.tsx
+++ b/src/solver/layout/nodes/resource-node/ResourceNode.tsx
@@ -56,6 +56,7 @@ export const ResourceNode = memo((props: IResourceNodeProps) => {
     if (input.factoryId === WORLD_SOURCE_ID) return WORLD_SOURCE_ID;
     const factory = state.factories.factories[input.factoryId ?? ''];
     return {
+      id: factory?.id,
       name: factory?.name,
       // TODO Support multiple outputs
       outputAmount: factory?.outputs.find(o => o.resource === resource.id)
@@ -101,7 +102,10 @@ export const ResourceNode = memo((props: IResourceNodeProps) => {
               </Group>
               <Group gap={4} align="center">
                 {sourceFactory != null && (
-                  <Tooltip label="Input from another factory">
+                  <Tooltip
+                    label="Input from another factory"
+                    disabled={sourceFactory === WORLD_SOURCE_ID}
+                  >
                     <FactoryInputIcon size={16} stroke={2} />
                   </Tooltip>
                 )}

--- a/src/solver/layout/nodes/resource-node/ResourceNodeInput.tsx
+++ b/src/solver/layout/nodes/resource-node/ResourceNodeInput.tsx
@@ -3,9 +3,22 @@ import { FactoryInputIcon } from '@/factories/components/peek/icons/OutputInputI
 import { BaseFactoryUsage } from '@/factories/components/usage/FactoryUsage';
 import { WORLD_SOURCE_ID } from '@/factories/Factory';
 import { FactoryItemImage } from '@/recipes/ui/FactoryItemImage';
-import { Badge, Box, CloseButton, Group, Text, Title } from '@mantine/core';
-import { IconBuildingFactory2, IconWorld } from '@tabler/icons-react';
+import {
+  Anchor,
+  Badge,
+  Box,
+  CloseButton,
+  Group,
+  Text,
+  Title,
+} from '@mantine/core';
+import {
+  IconBuildingFactory2,
+  IconExternalLink,
+  IconWorld,
+} from '@tabler/icons-react';
 import { useReactFlow } from '@xyflow/react';
+import { Link } from 'react-router-dom';
 import type { IResourceNodeData } from './ResourceNode';
 
 export interface IResourceNodeInputProps {
@@ -14,7 +27,11 @@ export interface IResourceNodeInputProps {
   data: IResourceNodeData;
   sourceFactory?:
     | typeof WORLD_SOURCE_ID
-    | { name?: string | null; outputAmount?: number | null };
+    | {
+        id?: string | null;
+        name?: string | null;
+        outputAmount?: number | null;
+      };
 }
 
 export function ResourceNodeInput(props: IResourceNodeInputProps) {
@@ -49,9 +66,22 @@ export function ResourceNodeInput(props: IResourceNodeInputProps) {
             ) : (
               <IconBuildingFactory2 size={16} />
             )}
-            {sourceFactory === WORLD_SOURCE_ID
-              ? 'World'
-              : (sourceFactory?.name ?? 'Unknown Factory')}
+            {sourceFactory === WORLD_SOURCE_ID ? (
+              'World'
+            ) : sourceFactory ? (
+              <Anchor
+                component={Link}
+                to={`/factories/${sourceFactory?.id}/calculator`}
+                c="gray"
+              >
+                <Group gap={2}>
+                  {sourceFactory.name}
+                  <IconExternalLink size={12} />
+                </Group>
+              </Anchor>
+            ) : (
+              'Unknown Factory'
+            )}
           </Group>
         </Title>
         {props.selected && (


### PR DESCRIPTION
Found it annoying to keep going back to the factory page to navigate so this links to the source factory on inputs. Clicking on the factory name will navigate to the calculator page of that factory.

![image](https://github.com/user-attachments/assets/53480b40-42c1-454b-871f-503082c829db)

World inputs are not affected.

![image](https://github.com/user-attachments/assets/ee8a728c-102f-48be-a213-1d890d449ccb)
