### PR TITLE
Setting to enable edge animations

### DIFF
--- a/src/factories/charts/graph/edges/input-edge/InputEdge.tsx
+++ b/src/factories/charts/graph/edges/input-edge/InputEdge.tsx
@@ -1,6 +1,7 @@
 import { RepeatingNumber } from '@/core/intl/NumberFormatter';
 import { useChartSetting } from '@/factories/charts/store/chartsSlice';
 import type { FactoryInput } from '@/factories/Factory';
+import { useGameSettings } from '@/games/gamesSlice';
 import { AllLogisticTypesMap } from '@/recipes/logistics/LogisticTypes';
 import { FactoryItemImage } from '@/recipes/ui/FactoryItemImage';
 import { getEdgeParams, getSpecialPath } from '@/solver/edges/utils';
@@ -50,6 +51,8 @@ export const InputEdge: FC<EdgeProps<Edge<IInputEdgeData>>> = ({
 
   const widthMatchesInputAmount = useChartSetting('widthMatchesInputAmount');
 
+  const settings = useGameSettings();
+
   if (!sourceNode || !targetNode) {
     return null;
   }
@@ -91,13 +94,15 @@ export const InputEdge: FC<EdgeProps<Edge<IInputEdgeData>>> = ({
             sx < tx ? 'url(#edge-gradient)' : 'url(#edge-gradient-reverse)',
         }}
       />
-      <circle r="2" fill="var(--mantine-color-indigo-3)">
-        <animateMotion
-          dur={`${duration}s`}
-          repeatCount="indefinite"
-          path={edgePath}
-        />
-      </circle>
+      {settings.animateEdges ? (
+        <circle r="2" fill="var(--mantine-color-indigo-3)">
+          <animateMotion
+            dur={`${duration}s`}
+            repeatCount="indefinite"
+            path={edgePath}
+          />
+        </circle>
+      ) : null}
       <EdgeLabelRenderer>
         <Box
           p={'4px'}

--- a/src/games/Game.ts
+++ b/src/games/Game.ts
@@ -26,4 +26,5 @@ export interface GameSettings {
   highlight100PercentColor?: string;
   maxBelt?: string;
   maxPipeline?: string;
+  animateEdges?: boolean;
 }

--- a/src/games/settings/GameSettingsModal.tsx
+++ b/src/games/settings/GameSettingsModal.tsx
@@ -69,6 +69,12 @@ export function GameSettingsModal(props: IGameSettingsModalProps) {
             checked={settings?.noHighlight100PercentUsage}
             onChange={onChangeHandler('noHighlight100PercentUsage')}
           />
+          <Checkbox
+            label="Animate connections"
+            description="This will add little circles to the connections between nodes in the calculator to show resources moving between nodes. Disable if you don't like it"
+            checked={settings?.animateEdges}
+            onChange={onChangeHandler('animateEdges')}
+          />
           <ColorInput
             label="Highlight 100% usage color"
             description="Color used to highlight factories that are at 100% usage. By default it's a blue (#339af0)"

--- a/src/solver/edges/IngredientEdge.tsx
+++ b/src/solver/edges/IngredientEdge.tsx
@@ -1,6 +1,7 @@
 import {
   useGameSettingMaxBelt,
   useGameSettingMaxPipeline,
+  useGameSettings,
 } from '@/games/gamesSlice';
 import {
   FactoryConveyorBelts,
@@ -61,6 +62,7 @@ export const IngredientEdge: FC<EdgeProps<Edge<IIngredientEdgeData>>> = ({
   const isOverMaxBelt = maxBelt && (data?.value ?? 0) > maxBelt.conveyor!.speed;
   const isOverMaxPipeline =
     maxPipeline && (data?.value ?? 0) > maxPipeline.pipeline!.flowRate;
+  const settings = useGameSettings();
 
   const isOverMaxLogistic =
     data?.resource?.form === FactoryItemForm.Gas ||
@@ -123,13 +125,15 @@ export const IngredientEdge: FC<EdgeProps<Edge<IIngredientEdgeData>>> = ({
             sx < tx ? 'url(#edge-gradient)' : 'url(#edge-gradient-reverse)',
         }}
       />
-      <circle r="2" fill="var(--mantine-color-indigo-3)">
-        <animateMotion
-          dur={`${duration}s`}
-          repeatCount="indefinite"
-          path={edgePath}
-        />
-      </circle>
+      {settings.animateEdges ? (
+        <circle r="2" fill="var(--mantine-color-indigo-3)">
+          <animateMotion
+            dur={`${duration}s`}
+            repeatCount="indefinite"
+            path={edgePath}
+          />
+        </circle>
+      ) : null}
       <EdgeLabelRenderer>
         <Box
           p={'4px'}


### PR DESCRIPTION
Adds a new setting to enable/disable the animations on the edges for accessibility reasons. Maybe in the future we can hook into the "use-reduced-motion" browser setting to set it to true/false by default.

![image](https://github.com/user-attachments/assets/e197171d-f493-4b3d-bcd6-e6f3245e7222)
