### PR TITLE
chore: recommend npm-version-lens extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,6 @@
     "vunguyentuan.vscode-postcss",
     "gruntfuggly.todo-tree",
     "dbaeumer.vscode-eslint",
-    "pflannery.vscode-versionlens"
+    "legalfina.npm-version-lens"
   ]
 }


### PR DESCRIPTION
## Recommend npm-version-lens

This PR updates `.vscode/extensions.json` to recommend [**npm-version-lens**](https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens) in place of the following extension(s):

- `pflannery.vscode-versionlens`

### Why?

**npm-version-lens** provides:
- Color-coded version indicators directly in `package.json`
- One-click version updates via an inline dropdown
- Inlay hints showing the latest available version

It is actively maintained and lightweight.

Marketplace: https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens