### PR TITLE
Feature/map remove header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7414,6 +7414,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/map/MapPage.tsx
+++ b/src/map/MapPage.tsx
@@ -1,7 +1,4 @@
-import { Group, Title } from '@mantine/core';
-import { IconMap2 } from '@tabler/icons-react';
 import { useStore } from '@/core/zustand';
-import { AfterHeaderSticky } from '@/layout/AfterHeaderSticky';
 import { FullHeightContainer } from '@/layout/FullHeightContainer';
 import { MapFiltersPanel } from './MapFiltersPanel';
 import classes from './MapPage.module.css';
@@ -11,23 +8,13 @@ export function MapPage() {
   const gameId = useStore(state => state.games.selected ?? null);
 
   return (
-    <>
-      <AfterHeaderSticky>
-        <Group gap="sm" justify="space-between">
-          <Group gap="sm">
-            <IconMap2 size={20} />
-            <Title order={4}>World Map</Title>
-          </Group>
-        </Group>
-      </AfterHeaderSticky>
-      <FullHeightContainer>
-        <div className={classes.layout}>
-          <MapFiltersPanel gameId={gameId} />
-          <div className={classes.mapArea}>
-            <WorldMapView gameId={gameId} />
-          </div>
+    <FullHeightContainer>
+      <div className={classes.layout}>
+        <MapFiltersPanel gameId={gameId} />
+        <div className={classes.mapArea}>
+          <WorldMapView gameId={gameId} />
         </div>
-      </FullHeightContainer>
-    </>
+      </div>
+    </FullHeightContainer>
   );
 }

--- a/src/map/ResourceMarkersLayer.tsx
+++ b/src/map/ResourceMarkersLayer.tsx
@@ -11,7 +11,11 @@ import {
   getExtractorsForResource,
   OVERCLOCK_STEPS,
 } from './extraction';
-import { getPurityLabel, getResourceMarkerIcon } from './markerIcons';
+import {
+  getPurityColor,
+  getPurityLabel,
+  getResourceMarkerIcon,
+} from './markerIcons';
 
 export interface ResourceMarkersLayerProps {
   nodes: WorldResourceNode[];
@@ -60,6 +64,7 @@ function buildPopupHtml(
   const name = escapeHtml(item?.displayName ?? node.resource);
   const imagePath = item?.imagePath?.replace('_256', '_64') ?? '';
   const purityLabel = getPurityLabel(node.purity);
+  const purityColor = getPurityColor(node.purity);
   const x = formatNumber(node.x);
   const y = formatNumber(node.y);
   const altitude =
@@ -116,7 +121,10 @@ function buildPopupHtml(
         ${imagePath ? `<img class="map-marker-popup__icon" src="${escapeHtml(imagePath)}" alt="" />` : ''}
         <div class="map-marker-popup__title">
           <div class="map-marker-popup__name">${name}${pills ? ` ${pills}` : ''}</div>
-          <div class="map-marker-popup__meta">${escapeHtml(purityLabel)} purity</div>
+          <div class="map-marker-popup__meta">
+            <span class="map-marker-popup__purity-dot" style="background-color:${purityColor};" aria-hidden="true"></span>
+            ${escapeHtml(purityLabel)} purity
+          </div>
         </div>
       </div>
       <dl class="map-marker-popup__stats">

--- a/src/map/WorldMapView.module.css
+++ b/src/map/WorldMapView.module.css
@@ -172,9 +172,21 @@
 }
 
 :global(.map-marker-popup__meta) {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-size: 12px;
   line-height: 1.3;
   color: var(--mantine-color-gray-4);
+}
+
+:global(.map-marker-popup__purity-dot) {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+  flex: 0 0 10px;
 }
 
 :global(.map-marker-popup__stats) {
@@ -327,8 +339,27 @@
   margin: 12px;
 }
 
-:global(.leaflet-popup-content-wrapper) :global(.leaflet-popup-close-button) {
+:global(.leaflet-container) :global(a.leaflet-popup-close-button) {
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  box-sizing: border-box;
+  display: block;
+  text-align: center;
+  border-radius: var(--mantine-radius-sm);
   color: var(--mantine-color-gray-3);
+  font: 700 16px/28px var(--mantine-font-family);
+  text-decoration: none;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+:global(.leaflet-container) :global(a.leaflet-popup-close-button:hover) {
+  background-color: var(--mantine-color-dark-5);
+  color: var(--mantine-color-gray-0);
 }
 
 :global(.leaflet-control-zoom a) {

--- a/src/map/WorldMapView.module.css
+++ b/src/map/WorldMapView.module.css
@@ -5,6 +5,7 @@
   border-radius: var(--mantine-radius-md);
   overflow: hidden;
   background-color: var(--mantine-color-dark-8);
+  isolation: isolate;
 }
 
 .map {

--- a/src/map/WorldMapView.tsx
+++ b/src/map/WorldMapView.tsx
@@ -71,7 +71,10 @@ export function WorldMapView({ gameId }: WorldMapViewProps) {
         attributionControl={false}
         className={classes.map}
       >
-        <ImageOverlay url="/images/map/world-map.jpg" bounds={IMAGE_BOUNDS} />
+        <ImageOverlay
+          url="/images/map/world-map-5k.png"
+          bounds={IMAGE_BOUNDS}
+        />
         <ResourceMarkersLayer
           nodes={filteredNodes}
           usedNodes={usedNodes}


### PR DESCRIPTION
- 5K world map: added public/images/map/world-map-5k.png texture used by the ImageOverlay.
- Header removed: dropped the "World Map" sticky bar from MapPage, giving the canvas more room.
- z-index fix: added isolation: isolate on .mapShell to contain Leaflet's panes (markerPane 600, popupPane 700) which were leaking above the header dropdowns.
- Node popover: colored purity dot next to the label (reuses getPurityColor, red/yellow/green matching the marker ring); close button redone as a centered 28×28 rounded square with a visible hover state (the previous selector didn't match Leaflet's actual DOM structure).

<img width="463" height="271" alt="image" src="https://github.com/user-attachments/assets/d75ef17f-c124-4036-bb28-4207736f229f" />

<img width="601" height="398" alt="image" src="https://github.com/user-attachments/assets/1446eb79-41bd-41ca-97a0-a4cd6d9bc55d" />
