### PR TITLE
Editable overclock from ingredient rates + building rounding

### DIFF
--- a/src/solver/layout/nodes/machine-node/MachineNode.tsx
+++ b/src/solver/layout/nodes/machine-node/MachineNode.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionIcon,
   alpha,
   Badge,
   Box,
@@ -12,17 +13,20 @@ import {
   Table,
   Text,
   Title,
+  Tooltip,
   useMantineTheme,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
+  IconArrowDown,
+  IconArrowUp,
   IconBolt,
   IconBuildingFactory2,
   IconCircleCheckFilled,
   IconClockBolt,
 } from '@tabler/icons-react';
 import { type NodeProps, useReactFlow } from '@xyflow/react';
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { RepeatingNumber } from '@/core/intl/NumberFormatter';
 import { PercentageFormatter } from '@/core/intl/PercentageFormatter';
 import { useStore } from '@/core/zustand';
@@ -40,6 +44,7 @@ import { InvisibleHandles } from '@/solver/layout/rendering/InvisibleHandles';
 import { MachineNodeActions } from './MachineNodeActions';
 import { calculateMachineNodeBuildings } from './postprocess/calculateMachineNodeBuildings';
 import { RecipeIngredientRow } from './RecipeIngredientRow';
+import { roundOverclock } from './roundOverclock';
 
 export interface IMachineNodeData {
   label: string;
@@ -77,6 +82,41 @@ export const MachineNode = memo((props: IMachineNodeProps) => {
   const overclock = machineCalc.overclock;
   const buildingsAmount = machineCalc.buildingsAmount;
   const amplifiedRate = machineCalc.amplifiedRate;
+
+  const [overclockValue, setOverclockValue] = useState<number | string>(
+    nodeState?.overclock as number | string,
+  );
+
+  const editedOverclock =
+    overclockValue != null && overclockValue !== ''
+      ? Number(overclockValue)
+      : overclock;
+
+  // Back-solve overclock from a target whole-number building count, holding the
+  // node's required output rate (value) and amplified rate constant.
+  // buildingsAmount = value / perBuilding / overclock / amplifiedRate
+  const overclockForBuildings = (target: number) =>
+    roundOverclock(
+      value / (machineCalc.perBuilding * machineCalc.amplifiedRate * target),
+    );
+
+  const flooredBuildings = Math.floor(buildingsAmount);
+  const ceiledBuildings = Math.ceil(buildingsAmount);
+  const buildingsAreFractional = ceiledBuildings !== flooredBuildings;
+  const overclockIfRoundedDown =
+    flooredBuildings > 0 ? overclockForBuildings(flooredBuildings) : null;
+  const overclockIfRoundedUp =
+    ceiledBuildings > 0 ? overclockForBuildings(ceiledBuildings) : null;
+  // 2.5 == 250% is the same upper bound enforced by MachineNodeProductionConfig.
+  const canRoundDown =
+    buildingsAreFractional &&
+    overclockIfRoundedDown != null &&
+    overclockIfRoundedDown <= 2.5;
+  const canRoundUp =
+    buildingsAreFractional &&
+    overclockIfRoundedUp != null &&
+    overclockIfRoundedUp > 0;
+
   return (
     <Popover
       opened={(isHovering || props.selected) && !props.dragging}
@@ -250,17 +290,70 @@ export const MachineNode = memo((props: IMachineNodeProps) => {
                       <IconBuildingFactory2 size={16} /> x
                       <RepeatingNumber value={buildingsAmount} />{' '}
                       {building.name}
+                      {props.selected && buildingsAreFractional && (
+                        <Group gap={2} ml={4}>
+                          <Tooltip
+                            label={
+                              canRoundDown && overclockIfRoundedDown != null
+                                ? `Round down to ${flooredBuildings} at ${PercentageFormatter.format(overclockIfRoundedDown)} overclock`
+                                : 'Cannot round down'
+                            }
+                          >
+                            <ActionIcon
+                              size="xs"
+                              variant="subtle"
+                              disabled={!canRoundDown}
+                              onClick={() => {
+                                if (overclockIfRoundedDown != null) {
+                                  setOverclockValue(overclockIfRoundedDown);
+                                }
+                              }}
+                            >
+                              <IconArrowDown size={12} />
+                            </ActionIcon>
+                          </Tooltip>
+                          <Tooltip
+                            label={
+                              canRoundUp && overclockIfRoundedUp != null
+                                ? `Round up to ${ceiledBuildings} at ${PercentageFormatter.format(overclockIfRoundedUp)} overclock`
+                                : 'Cannot round up (would exceed 250% overclock)'
+                            }
+                          >
+                            <ActionIcon
+                              size="xs"
+                              variant="subtle"
+                              disabled={!canRoundUp}
+                              onClick={() => {
+                                if (overclockIfRoundedUp != null) {
+                                  setOverclockValue(overclockIfRoundedUp);
+                                }
+                              }}
+                            >
+                              <IconArrowUp size={12} />
+                            </ActionIcon>
+                          </Tooltip>
+                        </Group>
+                      )}
                     </Group>
-                    {machineCalc.partialBuildingAmount > 0 && (
-                      <Text size="xs" c="dimmed">
-                        {machineCalc.fullBuildingsAmount} at{' '}
-                        {PercentageFormatter.format(overclock)}
-                        {' + 1 at '}
-                        {PercentageFormatter.format(
-                          machineCalc.partialBuildingOverclock,
-                        )}
-                      </Text>
-                    )}
+                    {machineCalc.partialBuildingAmount > 0 &&
+                      // Hide the "X at A% + 1 at B%" split when A and B render
+                      // to the same string (e.g. after the round-up button
+                      // picks an overclock where every building runs at the
+                      // same rate). Comparing formatted output avoids picking
+                      // a fragile numeric tolerance when the values may have
+                      // drifted by float noise but display identically.
+                      PercentageFormatter.format(
+                        machineCalc.partialBuildingOverclock,
+                      ) !== PercentageFormatter.format(overclock) && (
+                        <Text size="xs" c="dimmed">
+                          {machineCalc.fullBuildingsAmount} at{' '}
+                          {PercentageFormatter.format(overclock)}
+                          {' + 1 at '}
+                          {PercentageFormatter.format(
+                            machineCalc.partialBuildingOverclock,
+                          )}
+                        </Text>
+                      )}
                   </Stack>
                   <Group gap={4} align="center">
                     <IconBolt size={16} />{' '}
@@ -315,8 +408,10 @@ export const MachineNode = memo((props: IMachineNodeProps) => {
                     ingredient={ingredient}
                     key={ingredient.resource}
                     buildingsAmount={buildingsAmount}
-                    overclock={overclock}
+                    overclock={editedOverclock}
                     amplifiedRate={amplifiedRate}
+                    editable={props.selected}
+                    onOverclockChange={setOverclockValue}
                   />
                 ))}
                 <Table.Tr>
@@ -334,8 +429,10 @@ export const MachineNode = memo((props: IMachineNodeProps) => {
                     ingredient={product}
                     key={product.resource}
                     buildingsAmount={buildingsAmount}
-                    overclock={overclock}
+                    overclock={editedOverclock}
                     amplifiedRate={amplifiedRate}
+                    editable={props.selected}
+                    onOverclockChange={setOverclockValue}
                   />
                 ))}
               </Table.Tbody>
@@ -347,6 +444,8 @@ export const MachineNode = memo((props: IMachineNodeProps) => {
                 data={props.data}
                 id={props.id}
                 buildingsAmount={buildingsAmount}
+                overclockValue={overclockValue}
+                setOverclockValue={setOverclockValue}
               />
             ) : (
               <Stack>

--- a/src/solver/layout/nodes/machine-node/MachineNodeActions.tsx
+++ b/src/solver/layout/nodes/machine-node/MachineNodeActions.tsx
@@ -19,6 +19,8 @@ export interface IMachineNodeActionsProps {
   data: IMachineNodeData;
 
   buildingsAmount: number;
+  overclockValue: number | string;
+  setOverclockValue: (value: number | string) => void;
 }
 
 /**
@@ -26,7 +28,7 @@ export interface IMachineNodeActionsProps {
  * These are the ones requiring the "apply" button.
  */
 export function MachineNodeActions(props: IMachineNodeActionsProps) {
-  const { data, buildingsAmount } = props;
+  const { data, buildingsAmount, overclockValue, setOverclockValue } = props;
   const { recipe, value } = data;
 
   const solverId = useFactoryContext();
@@ -48,17 +50,16 @@ export function MachineNodeActions(props: IMachineNodeActionsProps) {
     changed: recipesChanged,
   } = useRecipeAlternatesInputState(data.recipe.id);
 
-  // 2. Somersloops (stored per-machine, displayed per-machine) and overclock
-  // Clamp stored value to slotsPerBuilding for backward compat with old saves
-  // where the stored value was a total (0..buildings*slots).
+  // 2. Somersloops (stored per-machine, displayed per-machine).
+  // Overclock is lifted into the parent MachineNode so that ingredient rows
+  // can edit it inline (back-solving overclock from a desired /min rate).
+  // Clamp stored somersloops to slotsPerBuilding for backward compat with old
+  // saves where the stored value was a total (0..buildings*slots).
   const storedPerMachine = nodeState?.somersloops
     ? Math.min(nodeState.somersloops, slotsPerBuilding)
     : undefined;
   const [somersloopsValue, setSomersloopsValue] = useInputState(
     (storedPerMachine ?? '') as number | string,
-  );
-  const [overclockValue, setOverclockValue] = useInputState(
-    nodeState?.overclock as number | string,
   );
 
   const perMachineSomersloops = Number(somersloopsValue) || 0;

--- a/src/solver/layout/nodes/machine-node/MachineNodeProductionConfig.tsx
+++ b/src/solver/layout/nodes/machine-node/MachineNodeProductionConfig.tsx
@@ -3,6 +3,7 @@ import { AllFactoryBuildingsMap } from '@/recipes/FactoryBuilding';
 import type { FactoryItemId } from '@/recipes/FactoryItemId';
 import { FactoryItemImage } from '@/recipes/ui/FactoryItemImage';
 import type { IMachineNodeData } from './MachineNode';
+import { roundOverclock } from './roundOverclock';
 
 export interface IMachineNodeProductionConfigProps {
   id: string;
@@ -89,10 +90,14 @@ export function MachineNodeProductionConfig(
         value={
           overclockValue === '' || overclockValue == null
             ? ''
-            : Number(overclockValue) * 100
+            : // Round to 4 decimal places on the percent scale so values like
+              // 2.24 don't render as 224.00000000000003 from float pollution.
+              Math.round(Number(overclockValue) * 100 * 10000) / 10000
         }
         onValueChange={({ floatValue }) =>
-          setOverclockValue(floatValue == null ? '' : floatValue / 100)
+          setOverclockValue(
+            floatValue == null ? '' : roundOverclock(floatValue / 100),
+          )
         }
         min={0}
         max={250}

--- a/src/solver/layout/nodes/machine-node/RecipeIngredientRow.tsx
+++ b/src/solver/layout/nodes/machine-node/RecipeIngredientRow.tsx
@@ -1,8 +1,9 @@
-import { Table, Text } from '@mantine/core';
+import { NumberInput, Table, Text } from '@mantine/core';
 import { RepeatingNumber } from '@/core/intl/NumberFormatter';
 import { AllFactoryItemsMap } from '@/recipes/FactoryItem';
 import type { FactoryRecipe, RecipeIngredient } from '@/recipes/FactoryRecipe';
 import { FactoryItemImage } from '@/recipes/ui/FactoryItemImage';
+import { roundOverclock } from './roundOverclock';
 
 export const RecipeIngredientRow = ({
   index,
@@ -12,6 +13,8 @@ export const RecipeIngredientRow = ({
   buildingsAmount,
   overclock,
   amplifiedRate,
+  editable,
+  onOverclockChange,
 }: {
   index: number;
   type: 'Ingredients' | 'Products';
@@ -20,10 +23,12 @@ export const RecipeIngredientRow = ({
   buildingsAmount: number;
   overclock: number;
   amplifiedRate: number;
+  editable?: boolean;
+  onOverclockChange?: (overclock: number | string) => void;
 }) => {
   const item = AllFactoryItemsMap[ingredient.resource];
-  const amountPerMinute =
-    ((ingredient.displayAmount * 60) / recipe.time) * overclock;
+  const baseRate = (ingredient.displayAmount * 60) / recipe.time;
+  const amountPerMinute = baseRate * overclock;
   return (
     <Table.Tr>
       <Table.Td>
@@ -38,10 +43,34 @@ export const RecipeIngredientRow = ({
         </Text>
       </Table.Td>
       <Table.Td>
-        <Text size="sm" fs="italic">
-          <RepeatingNumber value={amountPerMinute} />
-          /min
-        </Text>
+        {editable && onOverclockChange ? (
+          <NumberInput
+            size="xs"
+            variant="filled"
+            suffix="/min"
+            value={Math.round(amountPerMinute * 1000) / 1000}
+            onValueChange={({ floatValue }) => {
+              if (floatValue == null || floatValue <= 0) return;
+              const newOverclock = roundOverclock(floatValue / baseRate);
+              onOverclockChange(newOverclock);
+            }}
+            min={0}
+            allowNegative={false}
+            decimalScale={3}
+            w={110}
+            styles={{
+              input: {
+                fontStyle: 'italic',
+                fontSize: 'var(--mantine-font-size-sm)',
+              },
+            }}
+          />
+        ) : (
+          <Text size="sm" fs="italic">
+            <RepeatingNumber value={amountPerMinute} />
+            /min
+          </Text>
+        )}
       </Table.Td>
       <Table.Td>
         <Text size="sm" fw="bold">

--- a/src/solver/layout/nodes/machine-node/roundOverclock.test.ts
+++ b/src/solver/layout/nodes/machine-node/roundOverclock.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { roundOverclock } from './roundOverclock';
+
+// Mirrors the display-side rounding done by MachineNodeProductionConfig so we
+// can verify what the user actually sees in the % NumberInput, not just the
+// stored multiplier.
+const displayPercent = (multiplier: number) =>
+  Math.round(multiplier * 100 * 10000) / 10000;
+
+describe('roundOverclock', () => {
+  test('keeps clean 2-decimal-percent values exact (75% -> 0.75)', () => {
+    expect(roundOverclock(0.75)).toBe(0.75);
+    expect(displayPercent(roundOverclock(0.75))).toBe(75);
+  });
+
+  test('regression: round-up button result that displayed as 224.00000000000003% now displays as 224%', () => {
+    // What the back-solve produces for a typical "round buildings up" case.
+    // Note: 2.2400000000000003 is the same float as 2.24, but we assert the
+    // display side using the same rounding the UI does.
+    const fromBackSolve = 2.24;
+    const rounded = roundOverclock(fromBackSolve);
+    expect(displayPercent(rounded)).toBe(224);
+  });
+
+  test('falls back to 4-decimal percent when 2dp would lose detail (2/3 -> 66.6667%)', () => {
+    const rounded = roundOverclock(2 / 3);
+    expect(displayPercent(rounded)).toBe(66.6667);
+  });
+
+  test('keeps 100% as exactly 1', () => {
+    expect(roundOverclock(1)).toBe(1);
+    expect(displayPercent(roundOverclock(1))).toBe(100);
+  });
+
+  test('handles min and max overclocks cleanly (1% and 250%)', () => {
+    expect(displayPercent(roundOverclock(0.01))).toBe(1);
+    expect(displayPercent(roundOverclock(2.5))).toBe(250);
+  });
+
+  test('passes through non-finite values', () => {
+    expect(roundOverclock(Number.NaN)).toBeNaN();
+    expect(roundOverclock(Number.POSITIVE_INFINITY)).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+  });
+});

--- a/src/solver/layout/nodes/machine-node/roundOverclock.ts
+++ b/src/solver/layout/nodes/machine-node/roundOverclock.ts
@@ -1,0 +1,25 @@
+/**
+ * Round an overclock multiplier to a sensible precision for display & storage.
+ *
+ * Strategy: work on the percent scale (multiplier * 100), prefer 2-decimal
+ * percent precision (e.g. 75.00%), and fall back to 4-decimal percent
+ * precision when 2dp would lose detail (e.g. 2/3 -> 66.6667% rather than
+ * 66.67%). Operating on the percent scale avoids the floating-point pollution
+ * that "/ 10000" would introduce on the multiplier scale (e.g. dividing by
+ * 100 vs 10000 for terminating decimals).
+ */
+export function roundOverclock(multiplier: number): number {
+  if (!Number.isFinite(multiplier)) return multiplier;
+
+  const percent = multiplier * 100;
+  const percent2dp = Math.round(percent * 100) / 100;
+  const percent4dp = Math.round(percent * 10000) / 10000;
+
+  // Tolerance is on the percent scale: if 2dp and 4dp agree to within
+  // ~1e-6 % they're effectively the same value (this also absorbs
+  // float-arithmetic noise from the multiplier->percent conversion).
+  const chosenPercent =
+    Math.abs(percent2dp - percent4dp) < 1e-6 ? percent2dp : percent4dp;
+
+  return chosenPercent / 100;
+}


### PR DESCRIPTION
Lets you tweak a machine's overclock by editing any ingredient's /min value directly in the row, or by rounding the building count up/down to the nearest whole number. Both paths back-solve the overclock and live preview across the popover before you hit Apply.

Also cleans up display: overclock values are normalized so 224% no longer shows as 224.00000000000003%, and the "X at A% + 1 at B%" split line hides itself when both percentages render to the same value.