### PR TITLE
feat: highlight factory expand icon when inputs are under-supplied

### DIFF
--- a/src/factories/components/expand/FactoryExpandActionIcon.tsx
+++ b/src/factories/components/expand/FactoryExpandActionIcon.tsx
@@ -4,24 +4,39 @@ import {
   IconArrowsDiagonalMinimize2,
 } from '@tabler/icons-react';
 import { useStore } from '@/core/zustand';
+
 export interface IFactoryExpandActionIconProps {
   isCollapsed: boolean;
   factoryId: string;
+  hasMissingInputs?: boolean;
 }
 
 export function FactoryExpandActionIcon(props: IFactoryExpandActionIconProps) {
-  const { isCollapsed, factoryId } = props;
+  const { isCollapsed, factoryId, hasMissingInputs } = props;
   return (
     <Tooltip label={isCollapsed ? 'Expand' : 'Collapse'}>
       <ActionIcon
         variant="subtle"
         color="gray"
         onClick={() => useStore.getState().toggleGameFactoryExpanded(factoryId)}
+        style={
+          hasMissingInputs
+            ? { border: '1px solid var(--mantine-color-error)' }
+            : undefined
+        }
       >
         {isCollapsed ? (
-          <IconArrowsDiagonal stroke={2} size={16} />
+          <IconArrowsDiagonal
+            stroke={2}
+            size={16}
+            color={hasMissingInputs ? 'var(--mantine-color-error)' : undefined}
+          />
         ) : (
-          <IconArrowsDiagonalMinimize2 stroke={2} size={16} />
+          <IconArrowsDiagonalMinimize2
+            stroke={2}
+            size={16}
+            color={hasMissingInputs ? 'var(--mantine-color-error)' : undefined}
+          />
         )}
       </ActionIcon>
     </Tooltip>

--- a/src/factories/components/usage/useFactoryHasMissingInputs.tsx
+++ b/src/factories/components/usage/useFactoryHasMissingInputs.tsx
@@ -1,0 +1,26 @@
+import { useStore } from '@/core/zustand';
+import { MANUAL_SOURCE_ID } from '@/factories/Factory';
+import { computeOutputUsage } from './useOutputUsage';
+
+/**
+ * Returns true when any of the factory's inputs is under-supplied by its
+ * source factory (mirrors the condition used by FactoryInputRow to show
+ * the "Missing X" indicator).
+ */
+export function useFactoryHasMissingInputs(factoryId: string) {
+  return useStore(state => {
+    const factory = state.factories.factories[factoryId];
+    if (!factory || factory.progress === 'disabled') return false;
+
+    const inputs = factory.inputs ?? [];
+    return inputs.some(input => {
+      if (!input?.resource || !input?.factoryId) return false;
+      if (input.factoryId === MANUAL_SOURCE_ID) return false;
+      const { percentage } = computeOutputUsage(state, {
+        factoryId: input.factoryId,
+        output: input.resource,
+      });
+      return percentage > 1;
+    });
+  });
+}

--- a/src/factories/components/usage/useOutputUsage.tsx
+++ b/src/factories/components/usage/useOutputUsage.tsx
@@ -1,63 +1,71 @@
-import { useStore } from '@/core/zustand';
+import { type RootState, useShallowStore } from '@/core/zustand';
 import { MANUAL_SOURCE_ID, WORLD_SOURCE_ID } from '@/factories/Factory';
 import { getWorldResourceMax } from '@/recipes/WorldResources';
 import type { IFactoryUsageProps } from './FactoryUsage';
 
-export function useOutputUsage(
+export interface OutputUsage {
+  percentage: number;
+  producedAmount: number;
+  usedAmount: number;
+  depotAmount: number;
+}
+
+/**
+ * Pure computation of how much of `output` is produced, depot-routed, and
+ * consumed for a given source `factoryId`. Shared by hooks that need to
+ * surface insufficient-supply state (e.g. `useOutputUsage`,
+ * `useFactoryHasMissingInputs`).
+ */
+export function computeOutputUsage(
+  state: RootState,
   options: Pick<IFactoryUsageProps, 'factoryId' | 'output'>,
-) {
-  const producedAmount = useStore(state => {
-    if (options.factoryId === WORLD_SOURCE_ID) {
-      return getWorldResourceMax(options.output);
-    }
-    if (options.factoryId === MANUAL_SOURCE_ID) {
-      // Manual inputs are user-supplied: no producer-side cap to enforce.
-      return Number.POSITIVE_INFINITY;
-    }
-    const source = state.factories.factories[options.factoryId ?? ''];
-    if (source?.progress === 'disabled') return 0;
-    return Math.max(
-      source?.outputs
-        ?.filter(
-          o => o?.resource === options.output && o?.destination !== 'depot',
-        )
-        .reduce((sum, o) => sum + (o?.amount ?? 0), 0) ?? 0,
-      0,
-    );
-  });
+): OutputUsage {
+  const { factoryId, output } = options;
 
-  const depotAmount = useStore(state => {
-    if (
-      options.factoryId === WORLD_SOURCE_ID ||
-      options.factoryId === MANUAL_SOURCE_ID
-    ) {
-      return 0;
+  let producedAmount: number;
+  if (factoryId === WORLD_SOURCE_ID) {
+    producedAmount = getWorldResourceMax(output);
+  } else if (factoryId === MANUAL_SOURCE_ID) {
+    // Manual inputs are user-supplied: no producer-side cap to enforce.
+    producedAmount = Number.POSITIVE_INFINITY;
+  } else {
+    const source = state.factories.factories[factoryId ?? ''];
+    if (source?.progress === 'disabled') {
+      producedAmount = 0;
+    } else {
+      producedAmount = Math.max(
+        source?.outputs
+          ?.filter(o => o?.resource === output && o?.destination !== 'depot')
+          .reduce((sum, o) => sum + (o?.amount ?? 0), 0) ?? 0,
+        0,
+      );
     }
-    const source = state.factories.factories[options.factoryId ?? ''];
-    if (source?.progress === 'disabled') return 0;
-    return Math.max(
-      source?.outputs
-        ?.filter(
-          o => o?.resource === options.output && o?.destination === 'depot',
-        )
-        .reduce((sum, o) => sum + (o?.amount ?? 0), 0) ?? 0,
-      0,
-    );
-  });
+  }
 
-  const usedAmount = useStore(
-    state =>
-      state.games.games[state.games.selected ?? '']?.factoriesIds
-        .map(id => state.factories.factories[id])
-        .filter(f => f && f.progress !== 'disabled')
-        .flatMap(f => f!.inputs)
-        .filter(
-          i =>
-            i?.resource === options.output &&
-            i?.factoryId === options.factoryId,
-        )
-        .reduce((sum, i) => sum + Math.max(i?.amount ?? 0, 0), 0) ?? 0,
-  );
+  let depotAmount: number;
+  if (factoryId === WORLD_SOURCE_ID || factoryId === MANUAL_SOURCE_ID) {
+    depotAmount = 0;
+  } else {
+    const source = state.factories.factories[factoryId ?? ''];
+    if (source?.progress === 'disabled') {
+      depotAmount = 0;
+    } else {
+      depotAmount = Math.max(
+        source?.outputs
+          ?.filter(o => o?.resource === output && o?.destination === 'depot')
+          .reduce((sum, o) => sum + (o?.amount ?? 0), 0) ?? 0,
+        0,
+      );
+    }
+  }
+
+  const usedAmount =
+    state.games.games[state.games.selected ?? '']?.factoriesIds
+      .map(id => state.factories.factories[id])
+      .filter(f => f && f.progress !== 'disabled')
+      .flatMap(f => f!.inputs)
+      .filter(i => i?.resource === output && i?.factoryId === factoryId)
+      .reduce((sum, i) => sum + Math.max(i?.amount ?? 0, 0), 0) ?? 0;
 
   let percentage = usedAmount / producedAmount;
   if (producedAmount === 0 && usedAmount !== 0) {
@@ -68,4 +76,10 @@ export function useOutputUsage(
   }
 
   return { percentage, producedAmount, usedAmount, depotAmount };
+}
+
+export function useOutputUsage(
+  options: Pick<IFactoryUsageProps, 'factoryId' | 'output'>,
+) {
+  return useShallowStore(state => computeOutputUsage(state, options));
 }

--- a/src/factories/list/FactoryRow.tsx
+++ b/src/factories/list/FactoryRow.tsx
@@ -19,6 +19,7 @@ import {
   FactoryInputIcon,
   FactoryOutputIcon,
 } from '@/factories/components/peek/icons/OutputInputIcons';
+import { useFactoryHasMissingInputs } from '@/factories/components/usage/useFactoryHasMissingInputs';
 import type { Factory } from '@/factories/Factory';
 import { FactoryInputRow } from '@/factories/inputs/input-row/FactoryInputRow';
 import { FactoryOutputRow } from '@/factories/inputs/output-row/FactoryOutputRow';
@@ -55,6 +56,7 @@ export function FactoryRow(props: IFactoryRowProps) {
 
   const isVisible = useIsFactoryVisible(id, true);
   const isCollapsed = useGameFactoryIsCollapsed(id);
+  const hasMissingInputs = useFactoryHasMissingInputs(id);
   if (!isVisible) return null;
 
   if (!factory) {
@@ -70,8 +72,12 @@ export function FactoryRow(props: IFactoryRowProps) {
     >
       <Group gap="sm" align="flex-start" justify="space-between">
         <Group gap="sm" align="flex-start">
-          <Group gap={2}>
-            <FactoryExpandActionIcon isCollapsed={isCollapsed} factoryId={id} />
+          <Group gap={4}>
+            <FactoryExpandActionIcon
+              isCollapsed={isCollapsed}
+              factoryId={id}
+              hasMissingInputs={hasMissingInputs}
+            />
             <TextInput
               variant="unstyled"
               placeholder="Factory..."


### PR DESCRIPTION
The expand/collapse icon next to a factory's name on /factories now turns red with a red outline when any of its inputs is short on supply, matching the existing 'Missing X' indicator on input rows. The shared calculation lives in computeOutputUsage so the row-level and factory-level signals stay in sync.

This means you can tell which factories are under-supplied even if the inputs list is collapsed.

Note that this was mainly generated by AI because I'm not familiar with the project or libraries used. But I've read all the code and it seems totally reasonable to me (I'm a software engineer). I assume you  don't object to AI code since you have {CLAUDE|AGENTS}.md files in the project.

<img width="1428" height="455" alt="collapsed" src="https://github.com/user-attachments/assets/6a586aea-76cc-440f-bfc0-dbdbfd58e216" />
<img width="1417" height="542" alt="expanded" src="https://github.com/user-attachments/assets/6106b293-c8c8-4253-a9b4-ea494b05bf35" />