### PR TITLE
feat: add pipe as transport option for fluids

### DIFF
--- a/src/factories/inputs/input-row/FactoryInputRow.tsx
+++ b/src/factories/inputs/input-row/FactoryInputRow.tsx
@@ -40,6 +40,7 @@ import { FactorySelectInput } from '@/factories/inputs/FactorySelectInput';
 import { useFactoryOnChangeHandler } from '@/factories/store/factoriesSelectors';
 import { useFactoryInputAssignedNodes } from '@/factories/store/factoryNodeAssignmentsSelectors';
 import { useIsFactoryVisible } from '@/factories/useIsFactoryVisible';
+import { AllFactoryItemsMap, FactoryItemForm } from '@/recipes/FactoryItem';
 import { LogisticTypeSelect } from '@/recipes/logistics/LogisticTypeSelect';
 import { WorldResourcesList } from '@/recipes/WorldResources';
 import { FactoryInputConstraintSelect } from './FactoryInputConstraintSelect';
@@ -148,6 +149,25 @@ export function FactoryInputRow(props: IFactoryInputRowProps) {
       }
     },
     [onChangeHandler, index, input.resource, factoryId],
+  );
+
+  const handleResourceChange = useCallback(
+    (selectedResource: string | null) => {
+      onChangeHandler(`inputs.${index}.resource`)(selectedResource);
+
+      // If the resource changes from a fluid to a solid and the transport type is set to pipe,
+      // unselect pipe since it is not a valid transport type for solids.
+      if (
+        selectedResource &&
+        input.transport === 'Pipe' &&
+        ![FactoryItemForm.Liquid, FactoryItemForm.Gas].includes(
+          AllFactoryItemsMap[selectedResource].form,
+        )
+      ) {
+        onChangeHandler(`inputs.${index}.transport`)(null);
+      }
+    },
+    [onChangeHandler, index, input.resource, input.transport],
   );
 
   const isVisible = useIsFactoryVisible(factoryId, false, input.resource);
@@ -325,7 +345,7 @@ export function FactoryInputRow(props: IFactoryInputRowProps) {
         allowedItems={allowedItems}
         size="sm"
         width={320}
-        onChange={onChangeHandler(`inputs.${index}.resource`)}
+        onChange={handleResourceChange}
       />
       <Tooltip
         label={
@@ -393,6 +413,13 @@ export function FactoryInputRow(props: IFactoryInputRowProps) {
       {displayMode === 'factory' && (
         <LogisticTypeSelect
           allowDeselect
+          isFluid={
+            input.resource
+              ? [FactoryItemForm.Liquid, FactoryItemForm.Gas].includes(
+                  AllFactoryItemsMap[input.resource].form,
+                )
+              : false
+          }
           value={input.transport}
           onChange={onChangeHandler(`inputs.${index}.transport`)}
           w={120}

--- a/src/recipes/logistics/LogisticTypeSelect.tsx
+++ b/src/recipes/logistics/LogisticTypeSelect.tsx
@@ -6,7 +6,9 @@ import {
 import { LogisticTypes } from './LogisticTypes';
 
 export interface ILogisticTypeSelectProps
-  extends Omit<ISelectInputProps, 'data'> {}
+  extends Omit<ISelectInputProps, 'data'> {
+  isFluid: boolean;
+}
 
 const LogisticOptions = LogisticTypes.map(logisticType => ({
   value: logisticType.id,
@@ -19,7 +21,9 @@ const LogisticOptions = LogisticTypes.map(logisticType => ({
 export function LogisticTypeSelect(props: ILogisticTypeSelectProps) {
   return (
     <SelectIconInput
-      data={LogisticOptions}
+      data={LogisticOptions.filter(
+        logisticOption => logisticOption.value !== 'Pipe' || props.isFluid,
+      )}
       placeholder="Transport"
       comboboxProps={{
         width: 120,

--- a/src/recipes/logistics/LogisticTypes.tsx
+++ b/src/recipes/logistics/LogisticTypes.tsx
@@ -1,5 +1,10 @@
 export const LogisticTypes = [
   {
+    id: 'Pipe',
+    name: 'Pipe',
+    imagePath: '/images/game/pipe-mk-1-indicator_64.png',
+  },
+  {
     id: 'Belt',
     name: 'Belt',
     imagePath: '/images/game/conveyor-mk-1_64.png',
@@ -19,10 +24,6 @@ export const LogisticTypes = [
     name: 'Vehicle',
     imagePath: '/images/game/tractor_64.png',
   },
-  // {
-  //   name: 'Pipe',
-  //   imagePath: "/images/game/pipeline_64.png"
-  // },
 ] as const;
 
 export type LogisticType = (typeof LogisticTypes)[number]['id'];


### PR DESCRIPTION
Add pipe as an option for transport when the resource is a fluid or a gas.  

https://github.com/user-attachments/assets/233239c0-990e-44ee-a5cc-c31bc61b57b6

